### PR TITLE
Revamp palette and streamline skills layout

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -10,14 +10,14 @@ export function About() {
       className="py-12 sm:py-16 lg:py-20 bg-gradient-to-b from-gray-900 to-gray-800"
     >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-600">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-emerald-600">
           About Me
         </h2>
 
         <div className="max-w-5xl mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 lg:gap-10">
             <div className="bg-gray-700/50 backdrop-blur-sm rounded-2xl p-4 sm:p-6 lg:p-8 shadow-xl transform hover:scale-[1.02] transition-all duration-300 border border-gray-600/30">
-              <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-blue-400">
+              <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-teal-400">
                 Education & Background
               </h3>
               <p className="text-gray-200 leading-relaxed mb-4 text-sm sm:text-base">
@@ -29,14 +29,14 @@ export function About() {
               </p>
               <ul className="space-y-3 text-gray-300">
                 <li className="flex items-start">
-                  <span className="text-blue-400 mr-2 mt-1">•</span>
+                  <span className="text-teal-400 mr-2 mt-1">•</span>
                   <span className="text-sm sm:text-base">
                     <strong>Michigan Technological University</strong> - M.S.
                     Computer Science (2024-2026)
                   </span>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-blue-400 mr-2 mt-1">•</span>
+                  <span className="text-teal-400 mr-2 mt-1">•</span>
                   <span className="text-sm sm:text-base">
                     <strong>Pune Institute of Computer Technology</strong> -
                     B.E. Computer Engineering (2019-2023)
@@ -46,7 +46,7 @@ export function About() {
             </div>
 
             <div className="bg-gray-700/50 backdrop-blur-sm rounded-2xl p-4 sm:p-6 lg:p-8 shadow-xl transform hover:scale-[1.02] transition-all duration-300 border border-gray-600/30">
-              <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-blue-400">
+              <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-teal-400">
                 Professional Interests
               </h3>
               <p className="text-gray-200 leading-relaxed mb-4 text-sm sm:text-base">
@@ -55,7 +55,7 @@ export function About() {
               </p>
               <ul className="space-y-3 text-gray-300">
                 <li className="flex items-start">
-                  <span className="text-blue-400 mr-2 mt-1">•</span>
+                  <span className="text-teal-400 mr-2 mt-1">•</span>
                   <span className="text-sm sm:text-base">
                     <strong>Machine Learning & Computer Vision</strong> -
                     Developing intelligent systems that can interpret visual
@@ -63,21 +63,21 @@ export function About() {
                   </span>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-blue-400 mr-2 mt-1">•</span>
+                  <span className="text-teal-400 mr-2 mt-1">•</span>
                   <span className="text-sm sm:text-base">
                     <strong>Full-Stack Development</strong> - Building
                     comprehensive web applications with modern frameworks
                   </span>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-blue-400 mr-2 mt-1">•</span>
+                  <span className="text-teal-400 mr-2 mt-1">•</span>
                   <span className="text-sm sm:text-base">
                     <strong>Edge Computing</strong> - Optimizing systems for
                     real-time processing at the network edge
                   </span>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-blue-400 mr-2 mt-1">•</span>
+                  <span className="text-teal-400 mr-2 mt-1">•</span>
                   <span className="text-sm sm:text-base">
                     <strong>IoT Solutions</strong> - Creating interconnected
                     device networks for smart applications
@@ -88,7 +88,7 @@ export function About() {
           </div>
 
           <div className="mt-6 sm:mt-8 lg:mt-10 bg-gray-700/50 backdrop-blur-sm rounded-2xl p-4 sm:p-6 lg:p-8 shadow-xl border border-gray-600/30">
-            <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-blue-400">
+            <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-teal-400">
               My Approach
             </h3>
             <p className="text-gray-200 leading-relaxed text-sm sm:text-base">

--- a/components/Awards.tsx
+++ b/components/Awards.tsx
@@ -29,7 +29,7 @@ export function Awards() {
   return (
     <section id="awards" className="py-12 sm:py-16 lg:py-20 bg-gray-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-600">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-emerald-600">
           Awards & Honors
         </h2>
         <div className="max-w-4xl mx-auto">
@@ -37,7 +37,7 @@ export function Awards() {
             {awards.map((award, index) => (
               <div
                 key={index}
-                className="group bg-gray-700/50 backdrop-blur-sm p-4 sm:p-6 rounded-2xl shadow-xl border border-gray-600/30 hover:border-blue-500/30 transition-all duration-300 hover:shadow-blue-500/10 hover:-translate-y-1"
+                className="group bg-gray-700/50 backdrop-blur-sm p-4 sm:p-6 rounded-2xl shadow-xl border border-gray-600/30 hover:border-teal-500/30 transition-all duration-300 hover:shadow-teal-500/10 hover:-translate-y-1"
               >
                 <div className="flex items-start gap-3">
                   <span className="text-2xl flex-shrink-0 mt-1">
@@ -47,7 +47,7 @@ export function Awards() {
                     <h3 className="text-sm sm:text-base font-medium text-gray-100 leading-tight mb-2 group-hover:text-white transition-colors duration-200">
                       {award.title}
                     </h3>
-                    <span className="text-blue-400 text-sm font-medium">
+                    <span className="text-teal-400 text-sm font-medium">
                       {award.year}
                     </span>
                   </div>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -10,7 +10,7 @@ export function Contact() {
           </p>
           <a
             href="mailto:aajuveka@mtu.edu"
-            className="text-blue-400 hover:underline text-sm md:text-base block mb-2"
+            className="text-teal-400 hover:underline text-sm md:text-base block mb-2"
           >
             aajuveka@mtu.edu
           </a>
@@ -20,7 +20,7 @@ export function Contact() {
               href="https://www.linkedin.com/in/ayushjuvekar/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-400 hover:underline text-sm md:text-base"
+              className="text-teal-400 hover:underline text-sm md:text-base"
             >
               LinkedIn Profile
             </a>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -38,21 +38,21 @@ export function Experience() {
       className="py-12 sm:py-16 lg:py-20 bg-gradient-to-b from-gray-800 to-gray-900"
     >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-600">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-emerald-600">
           Professional Experience
         </h2>
 
         <div className="max-w-4xl mx-auto">
-          <div className="relative border-l-2 border-blue-500/50 pl-6 sm:pl-8 ml-2 sm:ml-4 space-y-12 sm:space-y-16">
+          <div className="relative border-l-2 border-teal-500/50 pl-6 sm:pl-8 ml-2 sm:ml-4 space-y-12 sm:space-y-16">
             {experiences.map((exp, index) => (
               <div key={index} className="relative group">
                 {/* Timeline dot */}
-                <div className="absolute -left-[33px] sm:-left-[41px] -top-1 w-5 h-5 sm:w-6 sm:h-6 bg-gray-900 rounded-full border-2 border-blue-500 z-10 shadow-lg shadow-blue-500/20 group-hover:border-purple-500 transition-colors duration-300"></div>
+                <div className="absolute -left-[33px] sm:-left-[41px] -top-1 w-5 h-5 sm:w-6 sm:h-6 bg-gray-900 rounded-full border-2 border-teal-500 z-10 shadow-lg shadow-teal-500/20 group-hover:border-emerald-500 transition-colors duration-300"></div>
 
                 {/* Content card */}
-                <div className="bg-gray-700/50 backdrop-blur-sm p-4 sm:p-6 rounded-2xl shadow-xl border border-gray-600/30 transform transition-all duration-300 hover:shadow-blue-500/10 hover:-translate-y-1 hover:border-blue-500/30">
+                <div className="bg-gray-700/50 backdrop-blur-sm p-4 sm:p-6 rounded-2xl shadow-xl border border-gray-600/30 transform transition-all duration-300 hover:shadow-teal-500/10 hover:-translate-y-1 hover:border-teal-500/30">
                   <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-3 gap-2">
-                    <h3 className="text-lg sm:text-xl font-semibold text-blue-400">
+                    <h3 className="text-lg sm:text-xl font-semibold text-teal-400">
                       {exp.role}
                     </h3>
                     <div className="flex items-center text-gray-400 text-sm">
@@ -74,7 +74,7 @@ export function Experience() {
                     {exp.skills.map((skill, skillIndex) => (
                       <span
                         key={skillIndex}
-                        className="bg-gradient-to-br from-gray-600 to-gray-700 text-blue-300 text-xs px-3 py-1.5 rounded-lg border border-gray-500/20 hover:border-blue-400/30 transition-colors duration-200"
+                        className="bg-gradient-to-br from-gray-600 to-gray-700 text-teal-300 text-xs px-3 py-1.5 rounded-lg border border-gray-500/20 hover:border-teal-400/30 transition-colors duration-200"
                       >
                         {skill}
                       </span>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -69,7 +69,7 @@ export function Header() {
         <div className="flex justify-between items-center">
           <Link
             href="/"
-            className="text-lg sm:text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-600"
+            className="text-lg sm:text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-emerald-600"
           >
             Ayush Juvekar
           </Link>
@@ -80,7 +80,7 @@ export function Header() {
               href="/Ayush Juvekar_Resume.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="mr-3 sm:mr-4 text-xs sm:text-sm text-gray-300 hover:text-blue-400 flex items-center transition-colors"
+              className="mr-3 sm:mr-4 text-xs sm:text-sm text-gray-300 hover:text-teal-400 flex items-center transition-colors"
               download
             >
               <Download size={14} className="mr-1" />
@@ -104,7 +104,7 @@ export function Header() {
                 onClick={(e) => handleClick(e, link.id)}
                 className={`px-3 lg:px-4 py-2 rounded-md text-sm transition-colors ${
                   activeSection === link.id
-                    ? "text-blue-400 font-medium"
+                    ? "text-teal-400 font-medium"
                     : "text-gray-300 hover:text-white hover:bg-gray-800/30"
                 }`}
               >
@@ -115,7 +115,7 @@ export function Header() {
               href="/Ayush Juvekar_Resume.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="ml-2 px-3 lg:px-4 py-2 bg-blue-600/80 hover:bg-blue-700 text-white rounded-md transition-colors flex items-center text-sm"
+              className="ml-2 px-3 lg:px-4 py-2 bg-teal-600/80 hover:bg-teal-700 text-white rounded-md transition-colors flex items-center text-sm"
               download
             >
               <Download size={16} className="mr-1" />
@@ -141,8 +141,8 @@ export function Header() {
                   onClick={(e) => handleClick(e, link.id)}
                   className={`px-4 py-3 rounded-lg transition-colors min-h-[44px] flex items-center ${
                     activeSection === link.id
-                      ? "text-blue-400 bg-blue-500/10 font-medium"
-                      : "text-gray-300 hover:bg-gray-800/50 hover:text-white"
+                    ? "text-teal-400 bg-teal-500/10 font-medium"
+                    : "text-gray-300 hover:bg-gray-800/50 hover:text-white"
                   }`}
                 >
                   {link.name}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -9,15 +9,15 @@ export function Hero() {
     >
       {/* Animated particles background */}
       <div className="absolute inset-0 overflow-hidden opacity-20">
-        <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-blue-500 rounded-full mix-blend-multiply filter blur-xl animate-blob animation-delay-2000"></div>
-        <div className="absolute top-1/3 right-1/4 w-64 h-64 bg-purple-500 rounded-full mix-blend-multiply filter blur-xl animate-blob animation-delay-4000"></div>
-        <div className="absolute bottom-1/4 right-1/3 w-64 h-64 bg-pink-500 rounded-full mix-blend-multiply filter blur-xl animate-blob"></div>
+        <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-teal-500 rounded-full mix-blend-multiply filter blur-xl animate-blob animation-delay-2000"></div>
+        <div className="absolute top-1/3 right-1/4 w-64 h-64 bg-emerald-500 rounded-full mix-blend-multiply filter blur-xl animate-blob animation-delay-4000"></div>
+        <div className="absolute bottom-1/4 right-1/3 w-64 h-64 bg-lime-500 rounded-full mix-blend-multiply filter blur-xl animate-blob"></div>
       </div>
 
       <div className="text-center z-10 max-w-4xl w-full">
         <div className="relative inline-block mb-6 sm:mb-8">
           <div className="relative w-[180px] h-[180px] sm:w-[200px] sm:h-[200px] md:w-[250px] md:h-[250px] group mx-auto">
-            <div className="absolute inset-0 rounded-full bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 animate-spin-slow blur-md opacity-70"></div>
+            <div className="absolute inset-0 rounded-full bg-gradient-to-r from-teal-400 via-emerald-500 to-green-500 animate-spin-slow blur-md opacity-70"></div>
             <Image
               src="https://utfs.io/f/6bBGFcWk1gIAPAamxrSv9Tch7i2WK6ex4NUmSVzlIufbLZQA"
               alt="Ayush Juvekar"
@@ -29,13 +29,13 @@ export function Hero() {
           </div>
         </div>
 
-        <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 tracking-tight leading-tight">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 bg-clip-text text-transparent bg-gradient-to-r from-teal-400 via-emerald-500 to-green-500 tracking-tight leading-tight">
           Ayush Juvekar
         </h1>
 
         <div className="relative">
           <h2 className="text-lg sm:text-xl md:text-2xl text-gray-200 mb-6 sm:mb-8 font-light">
-            <span className="text-blue-400 font-normal">Graduate Student</span>{" "}
+            <span className="text-teal-400 font-normal">Graduate Student</span>{" "}
             in Computer Science
             <span className="block mt-1 text-base sm:text-lg md:text-xl text-gray-300">
               Specializing in Machine Learning, Computer Vision & Full-Stack
@@ -67,7 +67,7 @@ export function Hero() {
             href="/Ayush Juvekar_Resume.pdf"
             target="_blank"
             rel="noopener noreferrer"
-            className="bg-blue-600/80 hover:bg-blue-700 text-white px-3 sm:px-4 py-2 rounded-lg transition-all hover:scale-105 text-sm md:text-base"
+            className="bg-teal-600/80 hover:bg-teal-700 text-white px-3 sm:px-4 py-2 rounded-lg transition-all hover:scale-105 text-sm md:text-base"
             download
           >
             Download Resume
@@ -77,7 +77,7 @@ export function Hero() {
         <div className="flex justify-center space-x-4 sm:space-x-5 mb-8 sm:mb-10">
           <a
             href="mailto:aajuveka@mtu.edu"
-            className="text-gray-400 hover:text-blue-400 transition-colors p-2"
+            className="text-gray-400 hover:text-teal-400 transition-colors p-2"
             aria-label="Email"
           >
             <Mail size={22} className="sm:w-6 sm:h-6" />
@@ -86,7 +86,7 @@ export function Hero() {
             href="https://www.linkedin.com/in/ayushjuvekar/"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-400 hover:text-blue-400 transition-colors p-2"
+            className="text-gray-400 hover:text-teal-400 transition-colors p-2"
             aria-label="LinkedIn"
           >
             <Linkedin size={22} className="sm:w-6 sm:h-6" />
@@ -95,7 +95,7 @@ export function Hero() {
             href="https://github.com/AyushJ1001"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-400 hover:text-blue-400 transition-colors p-2"
+            className="text-gray-400 hover:text-teal-400 transition-colors p-2"
             aria-label="GitHub"
           >
             <Github size={22} className="sm:w-6 sm:h-6" />
@@ -103,7 +103,7 @@ export function Hero() {
         </div>
       </div>
 
-      <div className="absolute bottom-6 sm:bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce text-blue-400">
+      <div className="absolute bottom-6 sm:bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce text-teal-400">
         <ArrowDown size={24} className="sm:w-7 sm:h-7" />
       </div>
     </section>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -127,7 +127,7 @@ export function Projects() {
       className="py-12 sm:py-16 lg:py-20 bg-gradient-to-b from-gray-900 to-gray-800"
     >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-6xl">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-600">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-8 sm:mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-emerald-600">
           Projects
         </h2>
 
@@ -137,21 +137,21 @@ export function Projects() {
               key={index}
               className={`bg-gray-700/50 backdrop-blur-sm rounded-2xl overflow-hidden border ${
                 project.type === "research"
-                  ? "border-purple-500/50 shadow-xl group hover:border-purple-400/70"
-                  : "border-gray-600/30 shadow-xl group hover:border-blue-500/30"
-              } transition-all duration-300 hover:shadow-blue-500/10 hover:-translate-y-1`}
+                  ? "border-emerald-500/50 shadow-xl group hover:border-emerald-400/70"
+                  : "border-gray-600/30 shadow-xl group hover:border-teal-500/30"
+              } transition-all duration-300 hover:shadow-teal-500/10 hover:-translate-y-1`}
             >
               <div
                 className={`${
-                  project.type === "research" ? "bg-purple-900/20" : ""
+                  project.type === "research" ? "bg-emerald-900/20" : ""
                 } p-4 sm:p-6`}
               >
                 <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4 gap-2">
                   <h3
                     className={`text-lg sm:text-xl font-semibold leading-tight ${
                       project.type === "research"
-                        ? "text-purple-300"
-                        : "text-blue-400"
+                        ? "text-emerald-300"
+                        : "text-teal-400"
                     }`}
                   >
                     {project.title}
@@ -165,15 +165,15 @@ export function Projects() {
                 <div
                   className={`border-l-2 ${
                     project.type === "research"
-                      ? "border-purple-500/50"
-                      : "border-blue-500/30"
+                      ? "border-emerald-500/50"
+                      : "border-teal-500/30"
                   } pl-4 py-1 mb-4`}
                 >
                   <div className="flex items-center text-gray-300 text-sm space-x-2">
                     {project.type === "research" ? (
-                      <BookOpen size={14} className="text-purple-400" />
+                      <BookOpen size={14} className="text-emerald-400" />
                     ) : (
-                      <Laptop size={14} className="text-blue-400" />
+                      <Laptop size={14} className="text-teal-400" />
                     )}
                     <span>
                       {project.type === "research"
@@ -191,8 +191,8 @@ export function Projects() {
                       key={techIndex}
                       className={`${
                         project.type === "research"
-                          ? "bg-gradient-to-br from-purple-900/40 to-purple-800/40 text-purple-200 border-purple-600/30"
-                          : "bg-gradient-to-br from-gray-600 to-gray-700 text-blue-300 border-gray-500/20"
+                          ? "bg-gradient-to-br from-emerald-900/40 to-emerald-800/40 text-emerald-200 border-emerald-600/30"
+                          : "bg-gradient-to-br from-gray-600 to-gray-700 text-teal-300 border-gray-500/20"
                       } text-xs px-3 py-1.5 rounded-lg border hover:border-opacity-50 transition-colors duration-200`}
                     >
                       {tech}
@@ -208,8 +208,8 @@ export function Projects() {
                       rel="noopener noreferrer"
                       className={`text-gray-400 ${
                         project.type === "research"
-                          ? "hover:text-purple-400"
-                          : "hover:text-blue-400"
+                          ? "hover:text-emerald-400"
+                          : "hover:text-teal-400"
                       } transition-colors flex items-center`}
                       aria-label="GitHub repository"
                     >
@@ -232,8 +232,8 @@ export function Projects() {
                       rel="noopener noreferrer"
                       className={`text-gray-400 ${
                         project.type === "research"
-                          ? "hover:text-purple-400"
-                          : "hover:text-blue-400"
+                          ? "hover:text-emerald-400"
+                          : "hover:text-teal-400"
                       } transition-colors flex items-center`}
                       aria-label="Live demo"
                     >

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -25,7 +25,6 @@ export function Skills() {
         "Rust",
         "C#",
       ],
-      gridCols: { mobile: 2, tablet: 4, desktop: 4 },
     },
     {
       title: "Frameworks",
@@ -44,7 +43,6 @@ export function Skills() {
         "OpenCV",
         "Flask",
       ],
-      gridCols: { mobile: 2, tablet: 3, desktop: 4 },
     },
     {
       title: "Domains",
@@ -57,13 +55,11 @@ export function Skills() {
         "Data Science",
         "Mobile Development",
       ],
-      gridCols: { mobile: 2, tablet: 3, desktop: 3 },
     },
     {
       title: "Tools",
       icon: "🛠️",
       skills: ["Docker", "Git", "Bash", "Linux", "VS Code", "Vim"],
-      gridCols: { mobile: 2, tablet: 3, desktop: 3 },
     },
     {
       title: "Office",
@@ -75,21 +71,8 @@ export function Skills() {
         "MS Excel",
         "Latex Overleaf",
       ],
-      gridCols: { mobile: 2, tablet: 3, desktop: 5 },
     },
   ];
-
-  const getGridClasses = (activeCategory: string) => {
-    const category = skillCategories.find(
-      (cat) => cat.title === activeCategory,
-    );
-    const { mobile, tablet, desktop } = category?.gridCols || {
-      mobile: 2,
-      tablet: 3,
-      desktop: 4,
-    };
-    return `grid-cols-${mobile} sm:grid-cols-${tablet} lg:grid-cols-${desktop}`;
-  };
 
   return (
     <section id="skills" className="py-12 sm:py-16 lg:py-20 bg-gray-800">
@@ -111,7 +94,7 @@ export function Skills() {
                   aria-controls="skills-panel"
                   className={`flex items-center gap-2 px-4 py-3 text-sm font-medium rounded-lg transition-all duration-200 whitespace-nowrap flex-shrink-0 ${
                     activeCategory === category.title
-                      ? "bg-blue-500 text-white shadow-lg"
+                      ? "bg-teal-500 text-white shadow-lg"
                       : "bg-gray-700 text-gray-300 hover:bg-gray-600"
                   }`}
                   onClick={() => setActiveCategory(category.title)}
@@ -130,7 +113,7 @@ export function Skills() {
                 key={category.title}
                 className={`flex items-center gap-2 px-4 py-3 lg:px-6 lg:py-3 text-sm lg:text-base font-medium rounded-lg transition-all duration-200 hover:scale-105 ${
                   activeCategory === category.title
-                    ? "bg-blue-500 text-white shadow-lg shadow-blue-500/25"
+                    ? "bg-teal-500 text-white shadow-lg shadow-teal-500/25"
                     : "bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white"
                 }`}
                 onClick={() => setActiveCategory(category.title)}
@@ -146,31 +129,24 @@ export function Skills() {
         <div className="bg-gray-700/50 backdrop-blur-sm p-4 sm:p-6 lg:p-8 rounded-2xl shadow-xl border border-gray-600/30">
           <div className="flex items-center gap-3 mb-6">
             <span className="text-2xl">
-              {
-                skillCategories.find((cat) => cat.title === activeCategory)
-                  ?.icon
-              }
+              {skillCategories.find((cat) => cat.title === activeCategory)?.icon}
             </span>
             <h3 className="text-xl sm:text-2xl font-semibold text-white">
               {activeCategory}
             </h3>
           </div>
 
-          {/* Optimized responsive grid for better alignment */}
-          <div
-            className={`grid gap-3 sm:gap-4 ${getGridClasses(activeCategory)}`}
-          >
+          {/* Compact skill tags for better mobile readability */}
+          <div className="flex flex-wrap gap-2 sm:gap-3">
             {skillCategories
               .find((category) => category.title === activeCategory)
               ?.skills.map((skill, index) => (
-                <div
+                <span
                   key={index}
-                  className="group bg-gradient-to-br from-gray-600 to-gray-700 p-3 sm:p-4 rounded-xl text-center transform hover:scale-105 transition-all duration-300 ease-out hover:from-gray-500 hover:to-gray-600 hover:shadow-lg hover:shadow-blue-500/10 border border-gray-500/20 hover:border-blue-400/30 min-h-[60px] sm:min-h-[70px] flex items-center justify-center"
+                  className="bg-gray-700 text-gray-100 px-3 py-1.5 rounded-lg text-xs sm:text-sm hover:bg-gray-600 transition-colors"
                 >
-                  <span className="text-xs sm:text-sm lg:text-base font-medium text-gray-100 leading-tight block group-hover:text-white transition-colors duration-200 px-1">
-                    {skill}
-                  </span>
-                </div>
+                  {skill}
+                </span>
               ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace generic blue/purple gradients with a teal/emerald palette
- condense technical skills section into tag-based layout for easier reading on small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b062af37a48327a411d3d2a0105021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Switched site-wide color theme to teal/emerald, updating headings, links, buttons, icons, cards, timelines, badges, and accents across About, Awards, Contact, Experience, Header, Hero, and Projects.
  - Refreshed Hero visuals: new gradients/blobs/avatar ring; social icons and download button align with the new palette; down-arrow color updated.
  - Slightly shortened/updated Hero subtitle copy.
  - Redesigned Skills section with a compact, chip-style layout for easier scanning.
  - Updated Projects and Awards card hover states and highlights to match the new theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->