### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,11 @@
 - Env vars: use `.env.local` for secrets; do not commit it. Access via `process.env.NEXT_PUBLIC_*` for browser‑safe values.
 - Assets: place public files under `public/` and reference with absolute paths (`/images/...`).
 - Accessibility: prefer semantic HTML, labeled controls, and keyboard‑navigable components.
+
+## Cursor Cloud specific instructions
+
+- **Single service:** Only a Next.js dev server is needed (`npm run dev` on port 3000). No databases, auth providers, or external APIs required.
+- **Geo-detection defaults:** The `/visitor` API route defaults to `"usa"` audience locally since `x-vercel-ip-country` / `cf-ipcountry` headers are absent outside Vercel/Cloudflare.
+- **Resume PDFs:** Pre-compiled PDFs exist in `public/`. Rebuilding from Typst sources (`npm run build:resumes`) is only needed if `.typ` files in `resumes/` are modified and requires the `typst` CLI (not installed by default).
+- **No env vars required:** The project runs with zero environment variables locally.
+- See "Build, Test, and Development Commands" above for standard commands.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development context for future cloud agents:

- Single-service architecture (Next.js only, no external deps)
- Geo-detection defaults when running locally
- Resume PDF rebuild requirements
- Zero env vars needed

This helps future agents start the dev server and test the portfolio without re-discovering these details.

[portfolio_demo_walkthrough.mp4](https://cursor.com/agents/bc-5e2d233c-25f5-4598-8946-65604eb7e8f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_demo_walkthrough.mp4)

Portfolio running locally — all sections render, in-page navigation works, and API routes (`/visitor`, `/resume`) respond correctly.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e2d233c-25f5-4598-8946-65604eb7e8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e2d233c-25f5-4598-8946-65604eb7e8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

